### PR TITLE
gpu_top makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ train:
 
 clean: 
 	rm -rf  ~/Research/psig-gan/runs/*
+
+gpu_top:
+	watch -n0.1 nvidia-smi


### PR DESCRIPTION
Add gpu_top command to the Makefile to shortcut alias procedure in Linux to view gpu in realtime